### PR TITLE
Lost Colony chronological order fix

### DIFF
--- a/Eggman/EggmanChronological.md
+++ b/Eggman/EggmanChronological.md
@@ -169,15 +169,15 @@
 
 [Back to Top](#)
 
-## Lost Colony Omochao 2
-![](./LostColony/Omochao-2nd-Far.webp)
-![](./LostColony/Omochao-2nd-Close.webp)
-
-[Back to Top](#)
-
 ## Lost Colony Pipe 1
 ![](./LostColony/Pipe-1st-Far.webp)
 ![](./LostColony/Pipe-1st-Close.webp)
+
+[Back to Top](#)
+
+## Lost Colony Omochao 2
+![](./LostColony/Omochao-2nd-Far.webp)
+![](./LostColony/Omochao-2nd-Close.webp)
 
 [Back to Top](#)
 


### PR DESCRIPTION
The first pipe and second Omochao in Lost Colony were ordered incorrectly.

https://user-images.githubusercontent.com/651417/230542995-c0a12365-dd8b-4e2a-a317-331c061f40c4.mp4

