### PR TITLE
Omochao 6 & 7 Chronological Fix

### DIFF
--- a/Tails/TailsChronological.md
+++ b/Tails/TailsChronological.md
@@ -368,6 +368,18 @@
 
 [Back to Top](#)
 
+## Eternal Engine Omochao 6
+![](./EternalEngine/Omochao-6th-Far.webp)
+![](./EternalEngine/Omochao-6th-Close.webp)
+
+[Back to Top](#)
+
+## Eternal Engine Omochao 7
+![](./EternalEngine/Omochao-7th-Far.webp)
+![](./EternalEngine/Omochao-7th-Close.webp)
+
+[Back to Top](#)
+
 ## Eternal Engine Chao Box 2
 ![](./EternalEngine/Chaobox-2nd-Far.webp)  
 ![](./EternalEngine/Chaobox-2nd-Close.webp)  
@@ -385,18 +397,6 @@
 ## Eternal Engine Pipe 3
 ![](./EternalEngine/Pipe-3rd-Far.webp)
 ![](./EternalEngine/Pipe-3rd-Close.webp)
-
-[Back to Top](#)
-
-## Eternal Engine Omochao 6
-![](./EternalEngine/Omochao-6th-Far.webp)
-![](./EternalEngine/Omochao-6th-Close.webp)
-
-[Back to Top](#)
-
-## Eternal Engine Omochao 7
-![](./EternalEngine/Omochao-7th-Far.webp)
-![](./EternalEngine/Omochao-7th-Close.webp)
 
 [Back to Top](#)
 


### PR DESCRIPTION
Omochao 6 and 7 come before Chao Box 2 on Eternal Engine
[SONIC ADVENTURE 2 4-19-2023 10-34-35 AM.mp4.av1.webm](https://user-images.githubusercontent.com/651417/233114858-9fcf9f00-302a-4962-9e78-9b39d0ad120c.webm)
