### PR TITLE
Lost Colony Chronological Order Fix

### DIFF
--- a/Eggman/Chronological/LostColony.md
+++ b/Eggman/Chronological/LostColony.md
@@ -18,15 +18,15 @@
 
 [Back to Top](#)
 
-## Lost Colony Omochao 2
-![](../LostColony/Omochao-2nd-Far.webp)
-![](../LostColony/Omochao-2nd-Close.webp)
-
-[Back to Top](#)
-
 ## Lost Colony Animal 3
 ![](../LostColony/Animal-3rd-Far.webp)
 ![](../LostColony/Animal-3rd-Close.webp)
+
+[Back to Top](#)
+
+## Lost Colony Omochao 2
+![](../LostColony/Omochao-2nd-Far.webp)
+![](../LostColony/Omochao-2nd-Close.webp)
 
 [Back to Top](#)
 


### PR DESCRIPTION
The corridor containing "Animal 3" is actually immediately before the room containing "Omochao 2"