### PR TITLE
Fix Chao Key 2 chronological ordering for Iron Gate

### DIFF
--- a/Eggman/Chronological/IronGate.md
+++ b/Eggman/Chronological/IronGate.md
@@ -70,12 +70,6 @@
 
 [Back to Top](#)
 
-## Iron Gate Chao Box 2
-![](../IronGate/Chaobox-2nd-Far.webp)  
-![](../IronGate/Chaobox-2nd-Close.webp)  
-
-[Back to Top](#)
-
 ## Iron Gate Animal 7
 ![](../IronGate/Animal-7th-Far.webp)
 ![](../IronGate/Animal-7th-Close.webp)
@@ -93,6 +87,12 @@
 ![](../IronGate/Animal-9th-Close.webp)
 
 [Back to Top](#)  
+
+## Iron Gate Chao Box 2
+![](../IronGate/Chaobox-2nd-Far.webp)  
+![](../IronGate/Chaobox-2nd-Close.webp)  
+
+[Back to Top](#)
 
 ## Iron Gate Pipe 3 & Animal 10
 ![](../IronGate/Pipe-3rd-Far.webp)


### PR DESCRIPTION
Out of the checks in the room with the Lost Chao, the Chao Key is closest to the exit, but was previously presented first in the guide. After these changes, it is presented after the other Lost Chao room checks.