### PR TITLE
Update Knuckles Chronological Wild Canyon

### DIFF
--- a/Knuckles/Chronological/WildCanyon.md
+++ b/Knuckles/Chronological/WildCanyon.md
@@ -65,7 +65,7 @@
 
 [Back to Top](#)
 
-## Wild Canyon Animal 5
+## Wild Canyon Pipe 2 & Animal 5
 ![](../WildCanyon/Animal-5th-Far.webp)
 ![](../WildCanyon/Animal-5th-Close.webp)
 
@@ -111,7 +111,7 @@
 
 [Back to Top](#)
 
-## Wild Canyon Animal 8
+## Wild Canyon Pipe 3 & Animal 8
 ![](../WildCanyon/Animal-8th-Far.webp)
 ![](../WildCanyon/Animal-8th-Close.webp)
 


### PR DESCRIPTION
Adds "pipe 2" and "pipe 3" labels to animal 5 & 8, matching formatting elsewhere